### PR TITLE
Add an example of mocking a successful response for tests.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,6 @@
+import mock
 import unittest
+import server
 from server import app
 import json
 
@@ -38,6 +40,25 @@ class ActivityMicroserviceTests(unittest.TestCase):
         result = self.client.get("/?zipcode=a&participants=0")
         self.assertEqual(result.status_code, 400)
         self.assertIn(b"error", result.data)
+
+    @mock.patch("server.requests.get")
+    def test_success_response(self, requests_patch):
+        # Construct the mock for a successful response
+        ok_response_mock = mock.MagicMock()
+        type(ok_response_mock).status_code = mock.PropertyMock(return_value=200)
+        fake_zip_json = {"places": [{"place name": "San Francisco"}]}
+        fake_activity_json = {"activity": "Go for a walk"}
+        ok_response_mock.json.side_effect = [fake_zip_json, fake_activity_json]
+
+        # Attach the ok response to the requests patch
+        requests_patch.return_value = ok_response_mock
+
+        result = self.client.get("/?zipcode=94301&participants=1")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(
+            result.json,
+            {"city": "San Francisco", "activity": "Go for a walk"}
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Example of constructing a mock object for faking `requests` library return values.
This mocks out the `status_code` attribute and `json` method for `requests.get`.